### PR TITLE
Drop Julia version requirement to 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6.7' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7.2' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6.7' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ ForwardDiff = "0.10"
 GaussQuadrature = "0.5"
 StaticArrays = "1"
 StructArrays = "0.6"
-julia = "1.7.2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/is_contained.jl
+++ b/src/is_contained.jl
@@ -23,12 +23,12 @@ function is_contained(curve, test_pt; ds=1e-4)
         # Use both < and > to ensure equality is not counted
         @. is_less_than = pt_curve < test_pt
         @. is_not_equal = pt_curve != test_pt
-        @. ray_was_crossed = (is_less_than != is_less_than_prev) && is_not_equal
+        @. ray_was_crossed = (is_less_than != is_less_than_prev) & is_not_equal
 
         # Note: reversing only works for 2D
         reverse!(ray_was_crossed)
-        @. above_indices = pt_curve > test_pt && ray_was_crossed
-        @. below_indices = pt_curve < test_pt && ray_was_crossed
+        @. above_indices = pt_curve > test_pt & ray_was_crossed
+        @. below_indices = pt_curve < test_pt & ray_was_crossed
 
         @. ray_intersections[above, above_indices] += ray_was_crossed[above_indices]
         @. ray_intersections[below, below_indices] += ray_was_crossed[below_indices]


### PR DESCRIPTION
It looks like the reason we need Julia 1.7 is because of the combination of `@.` and `&&`. Switching to `&` fixes this and tests seem to pass. 

@cgt3 - are you OK with this? If so feel free to merge this or just comment.