### PR TITLE
Improve type stability (attempt to reduce allocations) for `define_regions`

### DIFF
--- a/src/PiecewiseCurve.jl
+++ b/src/PiecewiseCurve.jl
@@ -6,18 +6,17 @@ function (f::ConstFunction)(x)
     return f.value
 end
 
-struct PiecewiseCurve{T_points, T_curves, T_bounds, 
-    T_continuity, T_closed, T_subArcLengths, T_arcLength} <: Function # Callable object for piecewise defined curves
+struct PiecewiseCurve{T_points, T_curves, T_bounds, T} <: Function # Callable object for piecewise defined curves
 
     stop_pts::T_points # Warning: these must be in increasing order and include s = 0,1
     subcurves::T_curves
     sub_bounds::T_bounds
     enforce_bounds::Bool
     
-    is_continuous::T_continuity
-    is_closed::T_closed
-    arc_lengths::T_subArcLengths
-    total_arc_length::T_arcLength
+    is_continuous::Bool
+    is_closed::Bool
+    arc_lengths::Vector{T}
+    total_arc_length::T
 end # struct PiecewiseCurve def
 
 function PiecewiseCurve(stop_pts, subcurves, sub_bounds; 

--- a/src/PiecewiseCurve.jl
+++ b/src/PiecewiseCurve.jl
@@ -62,7 +62,7 @@ function PiecewiseCurve(stop_pts, subcurves, sub_bounds;
         for j = 1:steps_per_segment
             sub_s = sub_s_prev + sub_ds
             pt = subcurves[i](sub_s)
-            arc_lengths[i] += norm(pt - pt_prev)
+            arc_lengths[i] += norm(pt .- pt_prev)
 
             sub_s_prev = sub_s
             pt_prev = pt

--- a/src/PiecewiseCurve.jl
+++ b/src/PiecewiseCurve.jl
@@ -86,7 +86,6 @@ function PiecewiseCurve(stop_pts, subcurves; enforce_bounds=true, continuity_tol
     return PiecewiseCurve(stop_pts, subcurves, sub_bounds, enforce_bounds=enforce_bounds, continuity_tol=continuity_tol, steps_per_segment=steps_per_segment)
 end
 
-const PiecwiseFunction{T_pts, T_curves, T_bounds, T_continuity} = PiecewiseCurve{T_pts, T_curves, T_bounds, T_continuity, nothing, nothing, nothing}
 function PiecewiseFunction(stop_pts, subcurves, sub_bounds; continuity_tol=DEFAULT_CONTINUITY_TOL, steps_per_segment=1000)
     return PiecewiseCurve(stop_pts, subcurves, sub_bounds, enforce_bounds=false, continuity_tol=continuity_tol, steps_per_segment=steps_per_segment)
 end

--- a/src/PiecewiseCurve.jl
+++ b/src/PiecewiseCurve.jl
@@ -61,7 +61,7 @@ function PiecewiseCurve(stop_pts, subcurves, sub_bounds;
         for j = 1:steps_per_segment
             sub_s = sub_s_prev + sub_ds
             pt = subcurves[i](sub_s)
-            arc_lengths[i] += norm(pt .- pt_prev)
+            arc_lengths[i] += norm(pt - pt_prev)
 
             sub_s_prev = sub_s
             pt_prev = pt

--- a/src/PiecewiseCurve.jl
+++ b/src/PiecewiseCurve.jl
@@ -6,17 +6,18 @@ function (f::ConstFunction)(x)
     return f.value
 end
 
-struct PiecewiseCurve{T_points, T_curves, T_bounds, T} <: Function # Callable object for piecewise defined curves
+struct PiecewiseCurve{T_points, T_curves, T_bounds, 
+    T_continuity, T_closed, T_subArcLengths, T_arcLength} <: Function # Callable object for piecewise defined curves
 
     stop_pts::T_points # Warning: these must be in increasing order and include s = 0,1
     subcurves::T_curves
     sub_bounds::T_bounds
     enforce_bounds::Bool
     
-    is_continuous::Bool
-    is_closed::Bool
-    arc_lengths::Vector{T}
-    total_arc_length::T
+    is_continuous::T_continuity
+    is_closed::T_closed
+    arc_lengths::T_subArcLengths
+    total_arc_length::T_arcLength
 end # struct PiecewiseCurve def
 
 function PiecewiseCurve(stop_pts, subcurves, sub_bounds; 

--- a/src/PresetGeometries.jl
+++ b/src/PresetGeometries.jl
@@ -78,25 +78,25 @@ function Rectangle(; Lx=1, Ly=1, x0=0, y0=0, theta0=0, orientation=1)
 
         first_corner = Lx / (2*(Lx + Ly))
     end
-    stop_pts = (0, first_corner, 0.5, 0.5+first_corner, 1)
-    sub_bounds = ((0,1), (0,1), (0,1), (0,1))
+    stop_pts = (0.0, first_corner, 0.5, 0.5+first_corner, 1.0)
+    sub_bounds = ((0.0, 1.0), (0.0, 1.0), (0.0, 1.0), (0.0, 1.0))
     func = PiecewiseCurve(stop_pts, edges, sub_bounds)
 
     return Rectangle(Lx, Ly, x0, y0, theta0, orientation, stop_pts, func)
 end
 
-function Ellipse(; Rx=1, Ry=1, x0=0, y0=0, theta0=0, orientation=1)
+function Ellipse(; Rx=1.0, Ry=1.0, x0=0.0, y0=0.0, theta0=0.0, orientation=1)
     return Ellipse(Rx, Ry, x0, y0, theta0, orientation)
 end
 
 # Simplified geometries
 const Square{T_L, T_x0, T_y0, T_theta0, T_orientation} = Rectangle{T_L, T_L, T_x0, T_y0, T_theta0, T_orientation}
-function Square(; L=1, x0=0, y0=0, theta0=0, orientation=1)
+function Square(; L=1.0, x0=0.0, y0=0.0, theta0=0.0, orientation=1)
     return Rectangle(Lx=L, Ly=L, x0=x0, y0=y0, theta0=theta0, orientation=orientation)
 end
 
 const Circle{T_R, T_x0, T_y0, T_theta0, T_orientation} = Ellipse{T_R, T_R, T_x0, T_y0, T_theta0, T_orientation}
-function Circle(; R=1, x0=0, y0=0, theta0=0, orientation=1)
+function Circle(; R=1.0, x0=0.0, y0=0.0, theta0=0.0, orientation=1)
     return Ellipse(R, R, x0, y0, theta0, orientation)
 end
 
@@ -149,7 +149,7 @@ function Pacman(; R=1, first_jaw=pi/4, second_jaw=7*pi/4, x0=0.0, y0=0.0, orient
                   Circle(R=R, x0=x0, y0=y0), # Note: the orientation is reversed by the subbounds when necessary 
                   Line(second_corner, (x0,y0))
                 );
-    sub_bounds = ( (0,1), (theta1/(2*pi), theta2/(2*pi)), (0,1) )
+    sub_bounds = ( (0.0, 1.0), (theta1/(2*pi), theta2/(2*pi)), (0.0, 1.0) )
     
     func = PiecewiseCurve(stop_pts, subcurves, sub_bounds)
     return Pacman(R, first_jaw, second_jaw, theta1, theta2, x0, y0, orientation, stop_pts, func)
@@ -169,12 +169,12 @@ function Fish(; scale=1, x0=0.0, y0=0.0)
     t2 = 0.81
     t3 = 0.95
 
-    stop_pts = (0, t1, t2, t3, 1)
+    stop_pts = (0.0, t1, t2, t3, 1.0)
     subcurves = ( Ellipse(Rx=scale*Rx, Ry=scale*Ry, x0=x0, y0=y0), 
                   Line(p4, p3),
                   Line(p3, p2),
                   Line(p2, p1) )
-    sub_bounds = ( (FISH_T_START, 1 - FISH_T_START), (0,1), (0,1), (0,1))
+    sub_bounds = ( (FISH_T_START, 1 - FISH_T_START), (0.0,1.0), (0.0,1.0), (0.0,1.0))
     func = PiecewiseCurve(stop_pts, subcurves, sub_bounds)
     return Fish(x0, y0, scale, stop_pts, func)
 end

--- a/src/define_regions.jl
+++ b/src/define_regions.jl
@@ -75,9 +75,7 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
 
     regions_by_element = zeros(Int, nx-1, ny-1)
     cutcell_indices = spzeros(Int, nx-1, ny-1)
-
-    T = eltype(first(mesh_coords))
-    cutcells = PiecewiseCurve{Vector{T}, Vector{Function}, Vector{Tuple{T, T}}, T}[]
+    cutcells = PiecewiseCurve[]
 
     num_curves = length(curves)
     

--- a/src/define_regions.jl
+++ b/src/define_regions.jl
@@ -77,7 +77,7 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
     cutcell_indices = spzeros(Int, nx-1, ny-1)
 
     T = eltype(first(mesh_coords))
-    cutcells = PiecewiseCurve{Vector{T}, Vector{Function}, Vector{Tuple{T, T}}, T}[]
+    cutcells = PiecewiseCurve{Vector{Float64}, Vector{Function}, Vector{Tuple{Float64, Float64}}, Float64}[]
 
     num_curves = length(curves)
     

--- a/src/define_regions.jl
+++ b/src/define_regions.jl
@@ -93,7 +93,12 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
             region = c
         end
         num_stop_pts = length(stop_pts[c])
-        tangent(s) = ForwardDiff.derivative(curves[c], s)
+
+        # add a let block to avoid closure performance type instability 
+        # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
+        tangent = let curve = curves[c]
+            tangent(s) = ForwardDiff.derivative(curve, s)
+        end
 
 
         # For filling in the curve's region later

--- a/src/define_regions.jl
+++ b/src/define_regions.jl
@@ -75,7 +75,9 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
 
     regions_by_element = zeros(Int, nx-1, ny-1)
     cutcell_indices = spzeros(Int, nx-1, ny-1)
-    cutcells = PiecewiseCurve[]
+
+    T = eltype(first(mesh_coords))
+    cutcells = PiecewiseCurve{Vector{T}, Vector{Function}, Vector{Tuple{T, T}}, T}[]
 
     num_curves = length(curves)
     

--- a/src/define_regions.jl
+++ b/src/define_regions.jl
@@ -110,9 +110,10 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
             entry_pt = stop_pts[c][i_entry]
             tan_entry = tangent(entry_pt.s)
 
-            cutcell_curves = Function[]
-            cutcell_sub_bounds = Tuple[] # TODO: can make type stable?
+            cutcell_curves = Function[]           
             sub_bounds = [1.0*entry_pt.s, entry_pt.s]
+            T = eltype(sub_bounds)
+            cutcell_sub_bounds = Tuple{T, T}[] 
 
             # 0) Make sure we have not left the domain
             if  (abs(entry_pt.pt[1] - mesh_coords[1][1] ) < edge_tol && tan_entry[1] < 0) || # x0
@@ -141,7 +142,8 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
                     end
                     sub_bounds[2] = stop_pts[c][j_next].s
                     push!(cutcell_curves, curves[c])
-                    push!(cutcell_sub_bounds, Tuple(sub_bounds))
+
+                    push!(cutcell_sub_bounds, (sub_bounds[1], sub_bounds[2]))
                     num_subcurves += 1
 
                     # WARNING: If tunneling is to be allowed this condition won't
@@ -187,13 +189,13 @@ function define_regions(mesh_coords, curves, stop_pts; binary_regions=false, edg
                     next_pt = ( mesh_coords[1][I_element[1] + pt_incr[(f+3) % 4 + 1][1]], 
                                 mesh_coords[2][I_element[2] + pt_incr[(f+3) % 4 + 1][2]] )
                     push!(cutcell_curves, Line(Tuple(curr_pt), Tuple(next_pt)))
-                    push!(cutcell_sub_bounds, (0,1))
+                    push!(cutcell_sub_bounds, (0.0, 1.0))
                     num_subcurves += 1
                     curr_pt = next_pt
                 end
                 # 5) Close the curve
                 push!(cutcell_curves, Line(Tuple(next_pt), Tuple(entry_pt.pt)))
-                push!(cutcell_sub_bounds, (0,1))
+                push!(cutcell_sub_bounds, (0.0, 1.0))
                 num_subcurves += 1
 
                 cutcell_stop_pts = [k/num_subcurves for k=0:num_subcurves]

--- a/src/find_mesh_intersections.jl
+++ b/src/find_mesh_intersections.jl
@@ -52,13 +52,13 @@ function find_mesh_intersections(coords, curve::Function,
     end
 
     # Walk along the curve, sensing for intersections in each dim
-    intersections = MeshIntersection[]
+    intersections = MeshIntersection{Float64, SVector{2, Float64}, Vector{Bool}, Vector{Int}}[]
     dim = zeros(Bool, numDim)
 
     s_new = s
     pt_new = pt_curr
     while s < 1
-        intersections_by_itr = MeshIntersection[]
+        intersections_by_itr = MeshIntersection{Float64, SVector{2, Float64}, Vector{Bool}, Vector{Int}}[]
 
         # Check if we are currently in the domain or crossing into or out of it
         curr_isInsideDomain = true
@@ -205,7 +205,7 @@ function find_mesh_intersections(coords, curves::Union{Array, Tuple},
     closure_tol=1e-12)
 
     numCurves = length(curves)
-    intersectionsByCurve = Vector{MeshIntersection}[]
+    intersectionsByCurve = Vector{MeshIntersection{Float64, SVector{2, Float64}, Vector{Bool}, Vector{Int}}}[]
 
     # Allow scalar arguments without changing functionality
     if typeof(ds) <:Real

--- a/src/find_mesh_intersections.jl
+++ b/src/find_mesh_intersections.jl
@@ -34,7 +34,7 @@ function find_mesh_intersections(coords, curve::Function,
         i_stop_pts = -1
     end
 
-    s = 0
+    s = 0.0
     pt_curr = curve(s)
     
     # Find the indices to the closest mesh values in each dimension

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PathIntersections
 using Test
 
+using StaticArrays
 using GaussQuadrature
 using LinearAlgebra
 

--- a/test/test_find_mesh_intersections.jl
+++ b/test/test_find_mesh_intersections.jl
@@ -8,8 +8,8 @@
     arc_tol = 1e-8
     corner_tol = 1e-8
 
-    circle(s, param) = [param.r*cos(2*pi*s) + param.x0, param.r*sin(2*pi*s) + param.y0]
-    circle_noParams(s) = [0.5*cos(2*pi*s), 0.5*sin(2*pi*s)]
+    circle(s, param) = SVector(param.r*cos(2*pi*s) + param.x0, param.r*sin(2*pi*s) + param.y0)
+    circle_noParams(s) = SVector(0.5*cos(2*pi*s), 0.5*sin(2*pi*s))
 
     @testset "Simple, single-dim" begin
         circle1(s) = circle(s, (; r=0.5, x0=0, y0=0.2))
@@ -134,7 +134,7 @@
 
     # 9. Complete code coverage by tripping intersections on lower boundaries
     @testset "Lower bound intersections" begin            
-        circle_neg(s) = [0.5*cos(-2*pi*s), 0.5*sin(-2*pi*s)]
+        circle_neg(s) = SVector(0.5*cos(-2*pi*s), 0.5*sin(-2*pi*s))
         
         x_coords = [-1 0 1]
         y_coords = [-1 -0.5 circle_neg(2*ds)[2] 0 1]
@@ -187,7 +187,7 @@
     # 12. Using a function for the step size
     @testset "Providing ds as a function; single curve" begin
         # A curve where the arc length per constant step in s varies        
-        ellipse(s) = [0.5*cos(2*pi*s), 0.05*sin(2*pi*s)]
+        ellipse(s) = SVector(0.5*cos(2*pi*s), 0.05*sin(2*pi*s))
         ds_func(s) = ds + ds*cos(2*pi*s)^2
 
         x_coords = [-1.0 0.0 1.0]


### PR DESCRIPTION
When benchmarking StartUpDG.jl's cut cell `MeshData` calls, I see a lot of allocations (using the Julia allocation profiler) and time spent in garbage collection in `PathIntersections.define_regions`. 
<img width="1840" alt="Screenshot 2024-05-10 at 1 23 19 AM" src="https://github.com/cgt3/PathIntersections.jl/assets/1156048/4f1186e6-c30e-4cdc-8a31-85b2f8003874">

This PR tries to identify sources of these allocations and reduce them. 

